### PR TITLE
Proper tag nesting.

### DIFF
--- a/forms/article/default.txp
+++ b/forms/article/default.txp
@@ -38,8 +38,8 @@
 <meta itemprop="url" content="<txp:image_url thumbnail="1" />">
 </figure>
 </txp:images>
-</txp:if_article_image>
 </div>
+</txp:if_article_image>
 </txp:if_individual_article>
 </div><!-- /flex-container -->
 </div><!-- /header -->


### PR DESCRIPTION
Avoid surplus closing DIV tag in article lists containing some image-less articles.